### PR TITLE
Fix spectral template name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export const templateNames = {
 	ELZEVIR: 'elzevir.ptf',
 	GROTESK: 'venus.ptf',
 	FELL: 'john-fell.ptf',
-	SPECTRAL: 'spectral.ptf',
+	SPECTRAL: 'gfnt.ptf',
 	ANTIQUE: 'antique.ptf',
 };
 
@@ -13,7 +13,7 @@ const validTemplates = [
 	'elzevir.ptf',
 	'venus.ptf',
 	'john-fell.ptf',
-	'spectral.ptf',
+	'gfnt.ptf',
 	'antique.ptf',
 ];
 


### PR DESCRIPTION
Spectral template file name is gfnt.ptf and as it is used with this name on the projects, we should use it everywhere like this.