### PR TITLE
Fix how fonts are loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,7 @@ export const templateNames = {
 	ANTIQUE: 'antique.ptf',
 };
 
-const validTemplates = [
-	'elzevir.ptf',
-	'venus.ptf',
-	'john-fell.ptf',
-	'gfnt.ptf',
-	'antique.ptf',
-];
+const validTemplates = Object.values(templateNames);
 
 const PtypoWorker = require('worker-loader?inline!./worker.js');
 
@@ -35,8 +29,21 @@ export default class Ptypo {
 				Authorization: `Bearer ${this.token}`,
 			},
 		});
-		const data = await font.json();
-		const json = JSON.parse(data);
+
+		if (!data.ok && data.statusCode === 403) {
+			throw new Error(
+				"The domain from where you're using the Prototypo library is not authorized. You can manage authorized domains in the developers page on your account. See https://app.prototypo.io/#/account/prototypo-library"
+			);
+		}
+
+		const json = await data.json();
+
+		if (!this.token /*|| TODO: check if AWS returned a free font */) {
+			console.warn(
+				"You're using the free version of the Prototypo library. Get a pro account now and access the entire glyphset. https://app.prototypo.io/#/account/subscribe"
+			);
+		}
+
 		const worker = new PtypoWorker();
 
 		return new Promise((resolve, reject) => {
@@ -58,7 +65,7 @@ export default class Ptypo {
 			worker.postMessage({
 				type: 'font',
 				name: fontName,
-				data,
+				data: JSON.stringify(json),
 			});
 		});
 	}


### PR DESCRIPTION
Change the way fonts are loaded (server now respond with JSON, not JSON string).
Warn the user if he is using the free version or if the domain is not accepted.
We also should define server-side a field we could use to specify if this is a free version of the font (maybe in `fontinfo` key ? or at the root).

As soon as this PR is deployed, please merge on the backend.